### PR TITLE
Add cloudformation helper scripts and a few improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM alpine:3.4
 MAINTAINER colin.hom@coreos.com
 
-RUN apk --update add bash curl less groff jq python py-pip
-RUN pip install awscli==1.11.15 s3cmd==1.6.1
-RUN mkdir /root/.aws
+RUN apk --no-cache --update add bash curl less groff jq python py-pip && \
+  pip install --no-cache-dir --upgrade pip && \
+  pip install --no-cache-dir awscli==1.11.15 s3cmd==1.6.1 https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz && \
+  apk del py-pip && \
+  mkdir /root/.aws


### PR DESCRIPTION
* Uninstall py-pip without creating unnecessary docker image layers. py-pip is not required at runtime.
* Add cloudformation helper scripts consists of well-known cfn-init, cfn-signal, etc to be used for deepder integration with cloudformation. To be used for e.g. https://github.com/coreos/kube-aws/issues/49.
* `apk add --no-cache` for not populating /var/apk/cache to reduce image size

ref https://github.com/coreos/kube-aws/issues/55

succeed to https://github.com/coreos/kube-aws/pull/56