### PR TITLE
Version locking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,6 @@ MAINTAINER colin.hom@coreos.com
 
 RUN apk --no-cache --update add bash curl less groff jq python py-pip && \
   pip install --no-cache-dir --upgrade pip && \
-  pip install --no-cache-dir awscli==1.11.15 s3cmd==1.6.1 https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz && \
+  pip install --no-cache-dir awscli==1.11.15 s3cmd==1.6.1 https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-1.4-8.tar.gz && \
   apk del py-pip && \
   mkdir /root/.aws


### PR DESCRIPTION
If we're going to lock awscli and s3cmd, we might as well version lock aws-cfn-bootstrap.