### PR TITLE
dockerfile: bump awscli, s3cmd, and cfn-bootstrap

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
-FROM alpine:3.4
+FROM alpine:3.6
 MAINTAINER colin.hom@coreos.com
 
 RUN apk --no-cache --update add bash curl less groff jq python py-pip && \
   pip install --no-cache-dir --upgrade pip && \
-  pip install --no-cache-dir awscli==1.11.15 s3cmd==1.6.1 https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-1.4-8.tar.gz && \
-  mkdir /root/.aws
+  pip install --no-cache-dir awscli==1.11.167 s3cmd==2.0.0 https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-1.4-24.tar.gz && \
+  mkdir /root/.aws && \
+  aws --version && \
+  s3cmd --version


### PR DESCRIPTION
This updates all of them to the latest available version.

This also adds a "can it run" check for aws and s3cmd at the end

I noticed this repo is referenced by the tectonic installer, so it seems worth updating it.

@squat since you made this pr https://github.com/coreos/tectonic-installer/pull/984 I'm going to ask if you can double check this doesn't break anything (or if you just wanna give it a LGTM on faith that it's fine, that's okay too)