### PR TITLE
Workaround for broken default execution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,3 +7,5 @@ RUN apk --no-cache --update add bash curl less groff jq python py-pip && \
   mkdir /root/.aws && \
   aws --version && \
   s3cmd --version
+
+CMD /bin/sh -c

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ RUN apk --no-cache --update add bash curl less groff jq python py-pip && \
   aws --version && \
   s3cmd --version
 
-CMD /bin/sh -c
+ENTRYPOINT []


### PR DESCRIPTION
Fixes broken kubernetes node bootup in kube-aws managed clusters. See #15