### PR TITLE
Include real wget to avoid busybox bugs included in alpine 3.6+

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.6
 MAINTAINER colin.hom@coreos.com
 
-RUN apk --no-cache --update add bash curl less groff jq python py-pip && \
+RUN apk --no-cache --update add bash curl less groff jq python py-pip wget && \
   pip install --no-cache-dir --upgrade pip && \
   pip install --no-cache-dir awscli==1.11.167 s3cmd==2.0.0 https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-1.4-24.tar.gz && \
   mkdir /root/.aws && \


### PR DESCRIPTION
The busybox imitation wget in alpine 3.6 appears to have problems with important AWS contexts, like `wget -O - -q http://169.254.169.254/2016-09-02/meta-data/instance-id` on the newer m5/c5 gen instances

An effective workaround is to include the alpine real 'wget' package. This patch does that.
Alternatively, reverting to alpine 3.5 apparently also fixes the busybox 'wget'.

https://github.com/kubernetes-incubator/kube-aws/issues/1369
gliderlabs/docker-alpine#292
gliderlabs/docker-alpine#344
https://git.busybox.net/busybox/commit/?id=a6f8651911716d1d1624712eb19e4f3608767c7e
apache/incubator-openwhisk#3715

(It would be nice to have version tags in the 'awscli' repo so people could e.g. revert to the working release, or if adding this full wget breaks for someone who was counting of some property of the busybox wget.)